### PR TITLE
ProcessRequest Refactor

### DIFF
--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapper.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapper.java
@@ -37,13 +37,20 @@ public class ContributionsFileMapper {
         return this;
     }
 
-    public File processRequest(String xmlData, LocalDate startDate, LocalDate endDate, String filename) throws JAXBException, IOException {
-        ContributionFile contributionFile = mapContributionsXmlStringToObject(xmlData);
+    public File processRequest(String[] xmlData, LocalDate startDate, LocalDate endDate, String filename) throws IOException, JAXBException {
         List<CSVDataLine> csvLineList = new ArrayList<>();
+        for (String xmlString: xmlData) {
+            processXMLFile(xmlString, startDate, endDate, csvLineList);
+        }
+        return csvFileService.writeContributionToCsv(csvLineList, filename);
+    }
+
+    private void processXMLFile(String xmlData, LocalDate startDate, LocalDate endDate, List<CSVDataLine> csvLineList) throws JAXBException {
+        ContributionFile contributionFile = mapContributionsXmlStringToObject(xmlData);
         for(CONTRIBUTIONS contribution : contributionFile.getCONTRIBUTIONSLIST().getCONTRIBUTIONS()){
             csvLineList.add(buildCSVDataLine(contribution, startDate, endDate));
         }
-        return csvFileService.writeContributionToCsv(csvLineList, filename);
+
     }
 
     public ContributionFile mapContributionsXMLFileToObject(File xmlFile) throws JAXBException {

--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/mapper/FdcFileMapper.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/mapper/FdcFileMapper.java
@@ -12,6 +12,8 @@ import uk.gov.justice.laa.crime.dces.report.service.CSVFileService;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class FdcFileMapper {
@@ -26,9 +28,12 @@ public class FdcFileMapper {
         return this;
     }
 
-    public File processRequest(String xmlData, String filename) throws JAXBException, IOException {
-        FdcFile fdcFile = mapFdcXmlStringToObject(xmlData);
-        return csvFileService.writeFdcToCsv(fdcFile, filename);
+    public File processRequest(String[] xmlData, String filename) throws JAXBException, IOException {
+        List<FdcFile> csvLineList = new ArrayList<>();
+        for (String xmlString: xmlData) {
+            csvLineList.add(mapFdcXmlStringToObject(xmlString));
+        }
+        return csvFileService.writeFdcFileListToCsv(csvLineList, filename);
     }
 
     public FdcFile mapFdcXmlStringToObject(String xmlString) throws JAXBException {

--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/service/CSVFileService.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/service/CSVFileService.java
@@ -55,6 +55,14 @@ public class CSVFileService {
         return targetFile;
     }
 
+    public File writeFdcFileListToCsv(List<FdcFile> fdcFiles, String fileName) throws IOException {
+        File targetFile = createCsvFile(fileName);
+        for(FdcFile file: fdcFiles){
+            writeFdcToCsv(file, targetFile);
+        }
+        return targetFile;
+    }
+
     public File writeFdcToCsv(FdcFile fdcFile, String fileName) throws IOException {
         File targetFile = createCsvFile(fileName);
         return writeFdcToCsv(fdcFile, targetFile);

--- a/dces-report-service/src/test/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapperTest.java
+++ b/dces-report-service/src/test/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapperTest.java
@@ -5,6 +5,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.UnmarshalException;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,6 +40,11 @@ class ContributionsFileMapperTest {
 
     private static final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("dd-MM-yyyy");
     private static final String filename = "this_is_a_test.xml";
+
+    @AfterEach
+    void resetCsvFileService(){
+        contributionsFileMapper.csvFileService = new CSVFileService();
+    }
 
     @Test
     void testXMLValid(){
@@ -134,18 +140,21 @@ class ContributionsFileMapperTest {
 
     @Test
     void testProcessRequestTooNew(){
+        File f = null;
         try {
             LocalDate startDate = getDate("01-01-2010");
             LocalDate endDate = getDate("01-01-2011");
             CSVFileService csvServiceMock = mock(CSVFileService.class);
             when(csvServiceMock.writeContributionToCsv(any(),anyString())).thenReturn(new File(filename));
             contributionsFileMapper.csvFileService=csvServiceMock;
-            File f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
+            f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
             softly.assertThat(f).isNotNull();
             softly.assertThat(f.getName()).isEqualTo(filename);
             softly.assertAll();
         } catch (JAXBException | IOException e) {
             fail("Exception occurred in mapping test:"+e.getMessage());
+        } finally {
+            if (Objects.nonNull(f)) { f.delete();}
         }
     }
 
@@ -155,18 +164,21 @@ class ContributionsFileMapperTest {
 
     @Test
     void testProcessRequestTooOld(){
+        File f = null;
         try {
             LocalDate startDate = getDate("01-01-2025");
             LocalDate endDate = getDate("01-01-2025");
             CSVFileService csvServiceMock = mock(CSVFileService.class);
             when(csvServiceMock.writeContributionToCsv(any(),anyString())).thenReturn(new File(filename));
             contributionsFileMapper.csvFileService=csvServiceMock;
-            File f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
+            f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
             softly.assertThat(f).isNotNull();
             softly.assertThat(f.getName()).isEqualTo(filename);
             softly.assertAll();
         } catch (JAXBException | IOException e) {
             fail("Exception occurred in mapping test:"+e.getMessage());
+        } finally {
+            if (Objects.nonNull(f)) { f.delete();}
         }
     }
 

--- a/dces-report-service/src/test/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapperTest.java
+++ b/dces-report-service/src/test/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapperTest.java
@@ -123,7 +123,7 @@ class ContributionsFileMapperTest {
             CSVFileService csvServiceMock = mock(CSVFileService.class);
             when(csvServiceMock.writeContributionToCsv(any(),anyString())).thenReturn(new File(filename));
             contributionsFileMapper.csvFileService=csvServiceMock;
-            File f = contributionsFileMapper.processRequest(getXMLString(), startDate, endDate, filename);
+            File f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
             softly.assertThat(f).isNotNull();
             softly.assertThat(f.getName()).isEqualTo(filename);
             softly.assertAll();
@@ -140,7 +140,7 @@ class ContributionsFileMapperTest {
             CSVFileService csvServiceMock = mock(CSVFileService.class);
             when(csvServiceMock.writeContributionToCsv(any(),anyString())).thenReturn(new File(filename));
             contributionsFileMapper.csvFileService=csvServiceMock;
-            File f = contributionsFileMapper.processRequest(getXMLString(), startDate, endDate, filename);
+            File f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
             softly.assertThat(f).isNotNull();
             softly.assertThat(f.getName()).isEqualTo(filename);
             softly.assertAll();
@@ -161,7 +161,7 @@ class ContributionsFileMapperTest {
             CSVFileService csvServiceMock = mock(CSVFileService.class);
             when(csvServiceMock.writeContributionToCsv(any(),anyString())).thenReturn(new File(filename));
             contributionsFileMapper.csvFileService=csvServiceMock;
-            File f = contributionsFileMapper.processRequest(getXMLString(), startDate, endDate, filename);
+            File f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
             softly.assertThat(f).isNotNull();
             softly.assertThat(f.getName()).isEqualTo(filename);
             softly.assertAll();
@@ -176,7 +176,7 @@ class ContributionsFileMapperTest {
         try {
             LocalDate startDate = getDate("01-01-2021");
             LocalDate endDate = getDate("02-02-2021");
-            f = contributionsFileMapper.processRequest(getXMLString(), startDate, endDate, filename);
+            f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
 
             softly.assertThat(f).isNotNull();
             String csvOutput = FileUtils.readText(f);
@@ -184,6 +184,31 @@ class ContributionsFileMapperTest {
             softly.assertThat(csvOutput).contains("MAAT ID,Data Feed Type,Assessment Date,CC OutCome Date,Correspondence Sent Date,Rep Order Status Date,Hardship Review Date,Passported Date");
             // verify content has been mapped
             softly.assertThat(csvOutput).contains("5635978,update,30/01/2021,25/01/2021,31/01/2021,25/01/2021,,");
+            softly.assertAll();
+        } catch (JAXBException | IOException e) {
+            fail("Exception occurred in mapping test:"+e.getMessage());
+        } finally {
+            if (Objects.nonNull(f)) { f.delete();}
+        }
+    }
+
+    @Test
+    void testProcessMultipleRequestFileGeneration(){
+        File f = null;
+        try {
+            LocalDate startDate = getDate("01-01-2021");
+            LocalDate endDate = getDate("02-02-2021");
+            f = contributionsFileMapper.processRequest(new String[]{getXMLString(),getXMLString()}, startDate, endDate, filename);
+
+            softly.assertThat(f).isNotNull();
+            String csvOutput = FileUtils.readText(f);
+            // check header present
+            softly.assertThat(csvOutput).contains("MAAT ID,Data Feed Type,Assessment Date,CC OutCome Date,Correspondence Sent Date,Rep Order Status Date,Hardship Review Date,Passported Date");
+            // verify content has been mapped
+            softly.assertThat(csvOutput).contains("5635978,update,30/01/2021,25/01/2021,31/01/2021,25/01/2021,,");
+            softly.assertThat(csvOutput).isEqualTo("MAAT ID,Data Feed Type,Assessment Date,CC OutCome Date,Correspondence Sent Date,Rep Order Status Date,Hardship Review Date,Passported Date\n" +
+                    "5635978,update,30/01/2021,25/01/2021,31/01/2021,25/01/2021,,\n" +
+                    "5635978,update,30/01/2021,25/01/2021,31/01/2021,25/01/2021,,");
             softly.assertAll();
         } catch (JAXBException | IOException e) {
             fail("Exception occurred in mapping test:"+e.getMessage());

--- a/dces-report-service/src/test/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapperTest.java
+++ b/dces-report-service/src/test/java/uk/gov/justice/laa/crime/dces/report/mapper/ContributionsFileMapperTest.java
@@ -123,18 +123,21 @@ class ContributionsFileMapperTest {
 
     @Test
     void testProcessRequest(){
+        File f = null;
         try {
             LocalDate startDate = getDate("01-01-2020");
             LocalDate endDate = getDate("01-01-2023");
             CSVFileService csvServiceMock = mock(CSVFileService.class);
             when(csvServiceMock.writeContributionToCsv(any(),anyString())).thenReturn(new File(filename));
             contributionsFileMapper.csvFileService=csvServiceMock;
-            File f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
+            f = contributionsFileMapper.processRequest(new String[]{getXMLString()}, startDate, endDate, filename);
             softly.assertThat(f).isNotNull();
             softly.assertThat(f.getName()).isEqualTo(filename);
             softly.assertAll();
         } catch (JAXBException | IOException e) {
             fail("Exception occurred in mapping test:"+e.getMessage());
+        } finally {
+            if (Objects.nonNull(f)) { f.delete();}
         }
     }
 


### PR DESCRIPTION
Changing processRequest to take a String[] instead of String.
Encapsulates the whole process, and abstracts away the processing from calling processes.

## What

Refactor the entry point for contribution and fdc mapping for better encapsulation.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
