### PR TITLE
Removing timer from notify due to breaking.

### DIFF
--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailClient.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailClient.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.crime.dces.report.utils.email;
 
-import io.micrometer.core.annotation.Timed;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +17,6 @@ public final class NotifyEmailClient implements EmailClient {
     @Autowired
     private NotificationClient client;
 
-    @Timed("email.send")
     @Override
     public void send(EmailObject emailObject) throws EmailClientException, EmailObjectInvalidException {
         NotifyEmailObject mail = (NotifyEmailObject) emailObject;


### PR DESCRIPTION
## What

Using @Timed on the Notify class is breaking the build. Quick PR to fix build while investigating why.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
