### PR TITLE
DCES-114: Updated WebClient factory to update header with a new LAA-TRANSACTION-ID for each request

### DIFF
--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/maatapi/MaatApiWebClientFactory.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/maatapi/MaatApiWebClientFactory.java
@@ -44,8 +44,8 @@ public class MaatApiWebClientFactory {
 
         WebClient.Builder clientBuilder = WebClient.builder()
             .baseUrl(servicesConfiguration.getMaatApi().getBaseUrl())
-            .filter(handleClientRequestBeforeSend())
-            .filter(handleClientResponse())
+            .filter(addLaaTransactionIdToRequest())
+            .filter(logClientResponse())
             .filter(handleErrorResponse())
             .clientConnector(new ReactorClientHttpConnector(
                 HttpClient.create(provider)
@@ -122,7 +122,7 @@ public class MaatApiWebClientFactory {
         );
     }
 
-    ExchangeFilterFunction handleClientRequestBeforeSend() {
+    ExchangeFilterFunction addLaaTransactionIdToRequest() {
         return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
                 String laaTransactionId = UUID.randomUUID().toString();
                 log.info("LAA_TRANSACTION_ID=[{}] Calling API [{}]", laaTransactionId, clientRequest.url());
@@ -136,7 +136,7 @@ public class MaatApiWebClientFactory {
         );
     }
 
-    ExchangeFilterFunction handleClientResponse() {
+    ExchangeFilterFunction logClientResponse() {
         return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
                 log.info("[{}] API response", clientResponse.statusCode());
                 return Mono.just(clientResponse);

--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/maatapi/MaatApiWebClientFactory.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/maatapi/MaatApiWebClientFactory.java
@@ -44,9 +44,8 @@ public class MaatApiWebClientFactory {
 
         WebClient.Builder clientBuilder = WebClient.builder()
             .baseUrl(servicesConfiguration.getMaatApi().getBaseUrl())
-            .defaultHeader(LAA_TRANSACTION_ID, UUID.randomUUID().toString())
-            .filter(logWebClientRequest())
-            .filter(logWebClientResponse())
+            .filter(handleClientRequestBeforeSend())
+            .filter(handleClientResponse())
             .filter(handleErrorResponse())
             .clientConnector(new ReactorClientHttpConnector(
                 HttpClient.create(provider)
@@ -123,23 +122,26 @@ public class MaatApiWebClientFactory {
         );
     }
 
-    ExchangeFilterFunction logWebClientRequest() {
+    ExchangeFilterFunction handleClientRequestBeforeSend() {
         return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
-            log.info("[{}] Making API call [{}]",
-                    clientRequest.headers().get(LAA_TRANSACTION_ID),
-                    clientRequest.url()
-            );
-            return Mono.just(clientRequest);
-        });
+                String laaTransactionId = UUID.randomUUID().toString();
+                log.info("LAA_TRANSACTION_ID=[{}] Calling API [{}]", laaTransactionId, clientRequest.url());
+                return Mono.just(
+                    ClientRequest
+                        .from(clientRequest)
+                        .header(LAA_TRANSACTION_ID, laaTransactionId)
+                        .build()
+                );
+            }
+        );
     }
 
-    ExchangeFilterFunction logWebClientResponse() {
+    ExchangeFilterFunction handleClientResponse() {
         return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
-            log.info("[{}] response",
-                    clientResponse.statusCode()
-            );
-            return Mono.just(clientResponse);
-        });
+                log.info("[{}] API response", clientResponse.statusCode());
+                return Mono.just(clientResponse);
+            }
+        );
     }
 
 


### PR DESCRIPTION
…-ID for each request

## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-XXX)

Updated MAAT API WebClient factory and it now set a new LAA-TRANSACTION-ID value for each request made. This value is still being passed in the header, just that it is no longer set during client creation. 
This way, we can now identify each call and that can also be traceable on MAAT API side

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
