### PR TITLE
Add Sentry Back In

### DIFF
--- a/dces-report-service/build.gradle
+++ b/dces-report-service/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     implementation "io.micrometer:micrometer-tracing-bridge-brave:$versions.micrometerio"
     implementation "io.micrometer:micrometer-registry-prometheus:$versions.prometheus"
 
+    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:6.27.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'


### PR DESCRIPTION
This reverts commit b2dac2c6251c24fae7accc64acffa26de2e6b578.

## What

Revert "Revert "Adding sentry to the project.""
It was accidentally removed, so re-adding.


## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
