### PR TITLE
Dces 456 improve report filename

### DIFF
--- a/dces-report-service/build.gradle
+++ b/dces-report-service/build.gradle
@@ -14,7 +14,7 @@ def versions = [
         jakartaActivation      : '2.0.1',
         resilience4jVersion    : '2.0.2',
         wiremockVersion        : '3.9.1',
-        notifyVersion          : '4.1.0-RELEASE'
+        notifyVersion          : '5.2.1-RELEASE'
 ]
 group = 'uk.gov.justice.laa.crime'
 

--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailObject.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailObject.java
@@ -46,7 +46,7 @@ public final class NotifyEmailObject implements EmailObject {
     @Override
     public void addAttachment(File file) throws IOException, NotificationClientException {
         byte[] fileContents = readFileToByteArray(file);
-        personalisation.put(uploadKey, NotificationClient.prepareUpload(fileContents, file.getName()+".csv"));
+        personalisation.put(uploadKey, NotificationClient.prepareUpload(fileContents, file.getName()));
     }
 
 }

--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailObject.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailObject.java
@@ -46,7 +46,7 @@ public final class NotifyEmailObject implements EmailObject {
     @Override
     public void addAttachment(File file) throws IOException, NotificationClientException {
         byte[] fileContents = readFileToByteArray(file);
-        personalisation.put(uploadKey, NotificationClient.prepareUpload(fileContents, file.getName()));
+        personalisation.put(uploadKey, NotificationClient.prepareUpload(fileContents, file.getName()+".csv"));
     }
 
 }

--- a/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailObject.java
+++ b/dces-report-service/src/main/java/uk/gov/justice/laa/crime/dces/report/utils/email/NotifyEmailObject.java
@@ -46,6 +46,7 @@ public final class NotifyEmailObject implements EmailObject {
     @Override
     public void addAttachment(File file) throws IOException, NotificationClientException {
         byte[] fileContents = readFileToByteArray(file);
-        personalisation.put(uploadKey, NotificationClient.prepareUpload(fileContents, true));
+        personalisation.put(uploadKey, NotificationClient.prepareUpload(fileContents, file.getName()));
     }
+
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DCES-456)

Use the new feature in Notify service to specify a more meaningful name to the downloaded CSV files.

Now the filenames are of the format Contributions_YYYY-MM-DD_YYYY-MM-DDXXXXXXXXXXXXXXXXXX.csv and FDC_YYYY-MM-DD_YYYY-MM-DDXXXXXXXXXXXXXXXXXX.csv instead of the completely random names. Unfortunately the service still appends a random string to the filename specified in the parameter which I have reported to them.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
